### PR TITLE
build: Explicitly use ts-node in esm mode in a different way

### DIFF
--- a/libs/logging-react/project.json
+++ b/libs/logging-react/project.json
@@ -35,7 +35,7 @@
     "publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node --loader ts-node/esm tools/scripts/publish.ts logging-react {args.ver} {args.tag}"
+        "command": "npx ts-node --esm tools/scripts/publish.ts logging-react {args.ver} {args.tag}"
       },
       "dependsOn": [
         {

--- a/libs/logging-transport-sentry-browser/project.json
+++ b/libs/logging-transport-sentry-browser/project.json
@@ -18,7 +18,7 @@
     "publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node --loader ts-node/esm tools/scripts/publish.ts logging-transport-sentry-browser {args.ver} {args.tag}"
+        "command": "npx ts-node --esm tools/scripts/publish.ts logging-transport-sentry-browser {args.ver} {args.tag}"
       },
       "dependsOn": [
         {

--- a/libs/logging-transport-sentry-node/project.json
+++ b/libs/logging-transport-sentry-node/project.json
@@ -18,7 +18,7 @@
     "publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node --loader ts-node/esm tools/scripts/publish.ts logging-transport-sentry-node {args.ver} {args.tag}"
+        "command": "npx ts-node --esm tools/scripts/publish.ts logging-transport-sentry-node {args.ver} {args.tag}"
       },
       "dependsOn": [
         {

--- a/libs/logging/project.json
+++ b/libs/logging/project.json
@@ -18,7 +18,7 @@
     "publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node --loader ts-node/esm tools/scripts/publish.ts logging {args.ver} {args.tag}"
+        "command": "npx ts-node --esm tools/scripts/publish.ts logging {args.ver} {args.tag}"
       },
       "dependsOn": [
         {


### PR DESCRIPTION
BREAKING CHANGE: Re-trigger previous failed major release